### PR TITLE
Add a filter so that data can be supplemented from outside the plugin

### DIFF
--- a/contact-form-cfdb-7.php
+++ b/contact-form-cfdb-7.php
@@ -92,6 +92,7 @@ function cfdb7_before_send_mail( $form_tag ) {
         }
 
         /* cfdb7 before save data. */
+        $form_data = apply_filters('cfdb7_before_save_data', $form_data); //Combine form data with any external hooks
         do_action( 'cfdb7_before_save_data', $form_data );
 
         $form_post_id = $form_tag->id();


### PR DESCRIPTION
As mentioned here: https://wordpress.org/support/topic/can-we-add-a-filter-prior-to-the-db-insert/

This will combine any other data that is manually hooked to it so we can store custom pieces of information along with each form submission.