### PR TITLE
Add custom capability to access cfdb7 in the WordPress Admin

### DIFF
--- a/contact-form-cfdb-7.php
+++ b/contact-form-cfdb-7.php
@@ -54,9 +54,27 @@ function cfdb7_on_activate( $network_wide ){
     } else {
         cfdb7_create_table();
     }
+
+	// Add custom capability
+	$role = get_role( 'administrator' );
+	$role->add_cap( 'cfdb7_access' );
 }
 
 register_activation_hook( __FILE__, 'cfdb7_on_activate' );
+
+
+function cfdb7_on_deactivate() {
+
+	// Remove custom capability from all roles
+	global $wp_roles;
+
+	foreach( array_keys( $wp_roles->roles ) as $role ) {
+		$wp_roles->remove_cap( $role, 'cfdb7_access' );
+	}
+}
+
+register_deactivation_hook( __FILE__, 'cfdb7_on_deactivate' );
+
 
 function cfdb7_before_send_mail( $form_tag ) {
 

--- a/inc/admin-mainpage.php
+++ b/inc/admin-mainpage.php
@@ -26,7 +26,10 @@ class Cfdb7_Wp_Main_Page
     {
         wp_enqueue_style( 'cfdb7-admin-style', plugin_dir_url(dirname(__FILE__)).'css/admin-style.css' );
 
-        add_menu_page( __( 'Contact Forms', 'contact-form-cfdb7' ), __( 'Contact Forms', 'contact-form-cfdb7' ), 'manage_options', 'cfdb7-list.php', array($this, 'list_table_page'), 'dashicons-list-view' );
+		// Fallback: Make sure admin always has access
+		$cfdb7_cap = ( current_user_can( 'cfdb7_access') ) ? 'cfdb7_access' : 'manage_options';
+
+        add_menu_page( __( 'Contact Forms', 'contact-form-cfdb7' ), __( 'Contact Forms', 'contact-form-cfdb7' ), $cfdb7_cap, 'cfdb7-list.php', array($this, 'list_table_page'), 'dashicons-list-view' );
 
          require_once 'add-ons.php';
 


### PR DESCRIPTION
- Adds the custom capability "cfdb7_access" and assigns it to the admin user on plugin activation.
- Removes the capability from all user roles on plugin deactivation.
- Fallback to make sure that users, who have already activated the plugin, still have access.