### PR TITLE
fix removed query params on notice link

### DIFF
--- a/contact-form-cfdb-7.php
+++ b/contact-form-cfdb-7.php
@@ -236,7 +236,7 @@ function cfdb7_admin_notice() {
 
         echo '<div class="updated"><p>';
 
-        printf(__( 'Awesome, you\'ve been using <a href="admin.php?page=cfdb7-list.php">Contact Form CFDB7</a> for more than 1 week. May we ask you to give it a 5-star rating on WordPress? | <a href="%2$s" target="_blank">Ok, you deserved it</a> | <a href="%1$s">I already did</a> | <a href="%1$s">No, not good enough</a>', 'contact-form-cfdb7' ), '?cfdb7-ignore-notice=0',
+        printf(__( 'Awesome, you\'ve been using <a href="admin.php?page=cfdb7-list.php">Contact Form CFDB7</a> for more than 1 week. May we ask you to give it a 5-star rating on WordPress? | <a href="%2$s" target="_blank">Ok, you deserved it</a> | <a href="%1$s">I already did</a> | <a href="%1$s">No, not good enough</a>', 'contact-form-cfdb7' ), add_query_arg('cfdb7-ignore-notice', 0, home_url() . add_query_arg([])),
         'https://wordpress.org/plugins/contact-form-cfdb7/');
         echo "</p></div>";
     }


### PR DESCRIPTION
The before link stripped away all query parameters, resulted in redirecting to other admin pages in some cases (when you were on a settings page of plugin which has its own query parameters).

Full URL is appended with the notice param now.