### PR TITLE
added compatibility for multi-file uploads

### DIFF
--- a/inc/admin-form-details.php
+++ b/inc/admin-form-details.php
@@ -55,13 +55,20 @@ class CFDB7_Form_Details
                             if( ! empty($matches[0]) ) continue;
 
                             if ( strpos($key, 'cfdb7_file') !== false ){
-
                                 $key_val = str_replace('cfdb7_file', '', $key);
                                 $key_val = str_replace('your-', '', $key_val);
                                 $key_val = str_replace( array('-','_'), ' ', $key_val);
                                 $key_val = ucwords( $key_val );
-                                echo '<p><b>'.$key_val.'</b>: <a href="'.$cfdb7_dir_url.'/'.$data.'">'
-                                .$data.'</a></p>';
+                                if (is_array($data)) {
+                                    $file_links = [];
+                                    foreach ($data as $inner_file) {
+                                        array_push($file_links, '<a href="'.$cfdb7_dir_url.'/'.$inner_file.'">'.$inner_file.'</a>');
+                                    }
+                                    echo '<p><b>'.$key_val.'</b>: '.implode(', ', $file_links).'</p>';
+                                } else {
+                                    echo '<p><b>'.$key_val.'</b>: <a href="'.$cfdb7_dir_url.'/'.$data.'">'
+                                    .$data.'</a></p>';
+                                }
                             }else{
 
 

--- a/inc/admin-subpage.php
+++ b/inc/admin-subpage.php
@@ -322,11 +322,16 @@ class CFDB7_List_Table extends WP_List_Table
 
                 foreach ($result_values as $key => $result) {
 
-                    if ( ( strpos($key, 'cfdb7_file') !== false ) &&
-                        ! empty( $result ) && 
-                        file_exists($cfdb7_dirname.'/'.$result) ) {
-
-                        unlink($cfdb7_dirname.'/'.$result);
+                    if ( ( strpos($key, 'cfdb7_file') !== false ) && !empty( $result )) {
+                        if (is_array($result)) {
+                            foreach ($result as $inner_file) {
+                                if (file_exists($cfdb7_dirname.'/'.$inner_file)) {
+                                    unlink($cfdb7_dirname.'/'.$inner_file);
+                                }
+                            }
+                        } else {
+                            unlink($cfdb7_dirname.'/'.$result);
+                        }
                     }
 
                 }

--- a/inc/export-csv.php
+++ b/inc/export-csv.php
@@ -126,8 +126,16 @@ class CFDB7_Export_CSV{
                         if( $rm_underscore ) preg_match('/^_.*$/m', $key, $matches);
                         if( ! empty($matches[0]) ) continue;
 
-                        if (strpos($key, 'cfdb7_file') !== false ){
-                            $data[$key][$i] = empty( $value ) ? '' : $cfdb7_dir_url.'/'.$value;
+                        if (strpos($key, 'cfdb7_file') !== false ){                           
+                            if (is_array($value)) {
+                                $file_list = [];
+                                foreach ($value as $inner_file) {
+                                    array_push($file_list, $cfdb7_dir_url.'/'.$inner_file);
+                                }
+                                $data[$key][$i] = implode(', ', $file_list);
+                            } else {
+                                $data[$key][$i] = empty( $value ) ? '' : $cfdb7_dir_url.'/'.$value;
+                            }
                             continue;
                         }
                         if ( is_array($value) ){


### PR DESCRIPTION
The pull request does not modify standard functionality but provides compatibility with plugins such as https://wordpress.org/plugins/multiline-files-for-contact-form-7/ to store multiple files being uploaded with a single field.

Pull request created as requested here: https://wordpress.org/support/topic/patch-multiple-files-uploaded/