### PR TITLE
form_values should be cleared for each result

### DIFF
--- a/inc/admin-subpage.php
+++ b/inc/admin-subpage.php
@@ -242,6 +242,7 @@ class CFDB7_List_Table extends WP_List_Table
         foreach ( $results as $result ) {
 
             $form_value = unserialize( $result->form_value );
+            $form_values = [];
 
             $link  = "<b><a href=admin.php?page=cfdb7-list.php&fid=%s&ufid=%s>%s</a></b>";
             if(isset($form_value['cfdb7_status']) && ( $form_value['cfdb7_status'] === 'read' ) )

--- a/inc/admin-subpage.php
+++ b/inc/admin-subpage.php
@@ -238,11 +238,10 @@ class CFDB7_List_Table extends WP_List_Table
                         LIMIT $start,100", OBJECT 
                     );
         }
-
+        $form_value = [];
         foreach ( $results as $result ) {
 
             $form_value = unserialize( $result->form_value );
-            $form_values = [];
 
             $link  = "<b><a href=admin.php?page=cfdb7-list.php&fid=%s&ufid=%s>%s</a></b>";
             if(isset($form_value['cfdb7_status']) && ( $form_value['cfdb7_status'] === 'read' ) )


### PR DESCRIPTION
form_values is not cleared in each loop. 

The previous value in result will pollute to the next result. 

For example, a result have a key "text-257" but the next result doesn't have the key then the value in the previous is keeped to the next result.