### PR TITLE
Allow customization of submission columns

### DIFF
--- a/inc/admin-subpage.php
+++ b/inc/admin-subpage.php
@@ -157,7 +157,7 @@ class CFDB7_List_Table extends WP_List_Table
         }
 
 
-        return $columns;
+        return apply_filters('cfdb7_admin_subpage_columns', $columns, $form_post_id);
     }
     /**
      * Define check box for bulk action (each row)


### PR DESCRIPTION
Dear author,

currently plugin gets four of the columns from the database and shows them in the table. This might not be optimal, as you might want to show different ones. This minor change allows column selection and/or reordering per each form.

Best regards,
Andrej