### PR TITLE
fix: reset form_values each iteration

### DIFF
--- a/inc/admin-subpage.php
+++ b/inc/admin-subpage.php
@@ -241,6 +241,7 @@ class CFDB7_List_Table extends WP_List_Table
 
         foreach ( $results as $result ) {
 
+            $form_values = [];
             $form_value = unserialize( $result->form_value );
 
             $link  = "<b><a href=admin.php?page=cfdb7-list.php&fid=%s&ufid=%s>%s</a></b>";


### PR DESCRIPTION
Problem was that for some forms i programatically set some fields and for some these fields are empty.

In the listview the entries that don't have that field set, get the data from the last entry that had that value set instead of being empty.

This PR ensures that in the loop that sets the data, first the form_values array is reset to be empty.
(unserialize somehow retains the data and doesn't reset the data first)