### PR TITLE
Add automatic capture of CF7 special mail tags in form submissions

### DIFF
--- a/contact-form-cfdb-7.php
+++ b/contact-form-cfdb-7.php
@@ -183,6 +183,99 @@ function cfdb7_before_send_mail( $form_tag ) {
             }
         }
 
+        /**
+         * Capture CF7 special mail tags used in the form's mail templates.
+         * Only saves tags that are actually referenced in the mail body/subject/headers.
+         *
+         * @since 1.3.6
+         */
+        $all_special_tags = cfdb7_get_special_mail_tags();
+
+        $mail_properties = (array) $contact_form->prop( 'mail' );
+        $mail_2 = (array) $contact_form->prop( 'mail_2' );
+        if ( ! empty( $mail_2['active'] ) ) {
+            $mail_properties = array_merge_recursive( $mail_properties, $mail_2 );
+        }
+        $mail_string = implode( ' ', array_map( function( $v ) {
+            return is_array( $v ) ? implode( ' ', $v ) : (string) $v;
+        }, $mail_properties ) );
+
+        $special_mail_tags = array();
+        foreach ( $all_special_tags as $tag ) {
+            if ( strpos( $mail_string, '[' . $tag . ']' ) !== false ) {
+                $special_mail_tags[] = $tag;
+            }
+        }
+
+        $special_mail_tags = apply_filters( 'cfdb7_active_special_mail_tags', $special_mail_tags, $contact_form );
+
+        $meta_map = array(
+            '_remote_ip'   => 'remote_ip',
+            '_user_agent'  => 'user_agent',
+            '_url'         => 'url',
+            '_date'        => 'timestamp',
+            '_time'        => 'timestamp',
+        );
+
+        foreach ( $special_mail_tags as $tag ) {
+            if ( isset( $form_data[$tag] ) ) continue;
+
+            $value = '';
+
+            if ( isset( $meta_map[$tag] ) ) {
+                $meta_value = $submission->get_meta( $meta_map[$tag] );
+                if ( $tag === '_date' && $meta_value ) {
+                    $value = wp_date( get_option( 'date_format' ), $meta_value );
+                } elseif ( $tag === '_time' && $meta_value ) {
+                    $value = wp_date( get_option( 'time_format' ), $meta_value );
+                } else {
+                    $value = $meta_value ? $meta_value : '';
+                }
+            } elseif ( $tag === '_post_id' ) {
+                $value = $submission->get_meta( 'container_post_id' );
+            } elseif ( $tag === '_post_name' && $submission->get_meta( 'container_post_id' ) ) {
+                $post = get_post( $submission->get_meta( 'container_post_id' ) );
+                $value = $post ? $post->post_name : '';
+            } elseif ( $tag === '_post_title' && $submission->get_meta( 'container_post_id' ) ) {
+                $value = get_the_title( $submission->get_meta( 'container_post_id' ) );
+            } elseif ( $tag === '_post_url' && $submission->get_meta( 'container_post_id' ) ) {
+                $value = get_permalink( $submission->get_meta( 'container_post_id' ) );
+            } elseif ( $tag === '_post_author' && $submission->get_meta( 'container_post_id' ) ) {
+                $post = get_post( $submission->get_meta( 'container_post_id' ) );
+                $value = $post ? get_the_author_meta( 'display_name', $post->post_author ) : '';
+            } elseif ( $tag === '_post_author_email' && $submission->get_meta( 'container_post_id' ) ) {
+                $post = get_post( $submission->get_meta( 'container_post_id' ) );
+                $value = $post ? get_the_author_meta( 'user_email', $post->post_author ) : '';
+            } elseif ( $tag === '_site_title' ) {
+                $value = get_bloginfo( 'name' );
+            } elseif ( $tag === '_site_url' ) {
+                $value = get_bloginfo( 'url' );
+            } elseif ( $tag === '_site_admin_email' ) {
+                $value = get_option( 'admin_email' );
+            } elseif ( $tag === '_user_login' && is_user_logged_in() ) {
+                $user  = wp_get_current_user();
+                $value = $user->user_login;
+            } elseif ( $tag === '_user_email' && is_user_logged_in() ) {
+                $user  = wp_get_current_user();
+                $value = $user->user_email;
+            } elseif ( $tag === '_user_url' && is_user_logged_in() ) {
+                $user  = wp_get_current_user();
+                $value = $user->user_url;
+            } elseif ( $tag === '_serial_number' ) {
+                $value = $cfdb->get_var(
+                    $cfdb->prepare(
+                        "SELECT COUNT(*) FROM $table_name WHERE form_post_id = %d",
+                        $form_tag->id()
+                    )
+                );
+                $value = intval( $value ) + 1;
+            }
+
+            if ( $value !== '' && $value !== false && $value !== null ) {
+                $form_data[$tag] = sanitize_text_field( (string) $value );
+            }
+        }
+
         $form_data = apply_filters('cfdb7_before_save_data', $form_data);
 
         do_action( 'cfdb7_before_save', $form_data );
@@ -204,6 +297,23 @@ function cfdb7_before_send_mail( $form_tag ) {
 }
 
 add_action( 'wpcf7_before_send_mail', 'cfdb7_before_send_mail' );
+
+
+/**
+ * Get the list of CF7 special mail tags saved by CFDB7.
+ *
+ * @since 1.3.6
+ * @return array
+ */
+function cfdb7_get_special_mail_tags() {
+    return apply_filters( 'cfdb7_special_mail_tags', array(
+        '_remote_ip', '_user_agent', '_url', '_date', '_time',
+        '_post_id', '_post_name', '_post_title', '_post_url',
+        '_post_author', '_post_author_email', '_serial_number',
+        '_site_title', '_site_url', '_site_admin_email',
+        '_user_login', '_user_email', '_user_url',
+    ) );
+}
 
 
 add_action( 'init', 'cfdb7_init');

--- a/contact-form-cfdb-7.php
+++ b/contact-form-cfdb-7.php
@@ -183,99 +183,6 @@ function cfdb7_before_send_mail( $form_tag ) {
             }
         }
 
-        /**
-         * Capture CF7 special mail tags used in the form's mail templates.
-         * Only saves tags that are actually referenced in the mail body/subject/headers.
-         *
-         * @since 1.3.6
-         */
-        $all_special_tags = cfdb7_get_special_mail_tags();
-
-        $mail_properties = (array) $contact_form->prop( 'mail' );
-        $mail_2 = (array) $contact_form->prop( 'mail_2' );
-        if ( ! empty( $mail_2['active'] ) ) {
-            $mail_properties = array_merge_recursive( $mail_properties, $mail_2 );
-        }
-        $mail_string = implode( ' ', array_map( function( $v ) {
-            return is_array( $v ) ? implode( ' ', $v ) : (string) $v;
-        }, $mail_properties ) );
-
-        $special_mail_tags = array();
-        foreach ( $all_special_tags as $tag ) {
-            if ( strpos( $mail_string, '[' . $tag . ']' ) !== false ) {
-                $special_mail_tags[] = $tag;
-            }
-        }
-
-        $special_mail_tags = apply_filters( 'cfdb7_active_special_mail_tags', $special_mail_tags, $contact_form );
-
-        $meta_map = array(
-            '_remote_ip'   => 'remote_ip',
-            '_user_agent'  => 'user_agent',
-            '_url'         => 'url',
-            '_date'        => 'timestamp',
-            '_time'        => 'timestamp',
-        );
-
-        foreach ( $special_mail_tags as $tag ) {
-            if ( isset( $form_data[$tag] ) ) continue;
-
-            $value = '';
-
-            if ( isset( $meta_map[$tag] ) ) {
-                $meta_value = $submission->get_meta( $meta_map[$tag] );
-                if ( $tag === '_date' && $meta_value ) {
-                    $value = wp_date( get_option( 'date_format' ), $meta_value );
-                } elseif ( $tag === '_time' && $meta_value ) {
-                    $value = wp_date( get_option( 'time_format' ), $meta_value );
-                } else {
-                    $value = $meta_value ? $meta_value : '';
-                }
-            } elseif ( $tag === '_post_id' ) {
-                $value = $submission->get_meta( 'container_post_id' );
-            } elseif ( $tag === '_post_name' && $submission->get_meta( 'container_post_id' ) ) {
-                $post = get_post( $submission->get_meta( 'container_post_id' ) );
-                $value = $post ? $post->post_name : '';
-            } elseif ( $tag === '_post_title' && $submission->get_meta( 'container_post_id' ) ) {
-                $value = get_the_title( $submission->get_meta( 'container_post_id' ) );
-            } elseif ( $tag === '_post_url' && $submission->get_meta( 'container_post_id' ) ) {
-                $value = get_permalink( $submission->get_meta( 'container_post_id' ) );
-            } elseif ( $tag === '_post_author' && $submission->get_meta( 'container_post_id' ) ) {
-                $post = get_post( $submission->get_meta( 'container_post_id' ) );
-                $value = $post ? get_the_author_meta( 'display_name', $post->post_author ) : '';
-            } elseif ( $tag === '_post_author_email' && $submission->get_meta( 'container_post_id' ) ) {
-                $post = get_post( $submission->get_meta( 'container_post_id' ) );
-                $value = $post ? get_the_author_meta( 'user_email', $post->post_author ) : '';
-            } elseif ( $tag === '_site_title' ) {
-                $value = get_bloginfo( 'name' );
-            } elseif ( $tag === '_site_url' ) {
-                $value = get_bloginfo( 'url' );
-            } elseif ( $tag === '_site_admin_email' ) {
-                $value = get_option( 'admin_email' );
-            } elseif ( $tag === '_user_login' && is_user_logged_in() ) {
-                $user  = wp_get_current_user();
-                $value = $user->user_login;
-            } elseif ( $tag === '_user_email' && is_user_logged_in() ) {
-                $user  = wp_get_current_user();
-                $value = $user->user_email;
-            } elseif ( $tag === '_user_url' && is_user_logged_in() ) {
-                $user  = wp_get_current_user();
-                $value = $user->user_url;
-            } elseif ( $tag === '_serial_number' ) {
-                $value = $cfdb->get_var(
-                    $cfdb->prepare(
-                        "SELECT COUNT(*) FROM $table_name WHERE form_post_id = %d",
-                        $form_tag->id()
-                    )
-                );
-                $value = intval( $value ) + 1;
-            }
-
-            if ( $value !== '' && $value !== false && $value !== null ) {
-                $form_data[$tag] = sanitize_text_field( (string) $value );
-            }
-        }
-
         $form_data = apply_filters('cfdb7_before_save_data', $form_data);
 
         do_action( 'cfdb7_before_save', $form_data );
@@ -299,23 +206,6 @@ function cfdb7_before_send_mail( $form_tag ) {
 add_action( 'wpcf7_before_send_mail', 'cfdb7_before_send_mail' );
 
 
-/**
- * Get the list of CF7 special mail tags saved by CFDB7.
- *
- * @since 1.3.6
- * @return array
- */
-function cfdb7_get_special_mail_tags() {
-    return apply_filters( 'cfdb7_special_mail_tags', array(
-        '_remote_ip', '_user_agent', '_url', '_date', '_time',
-        '_post_id', '_post_name', '_post_title', '_post_url',
-        '_post_author', '_post_author_email', '_serial_number',
-        '_site_title', '_site_url', '_site_admin_email',
-        '_user_login', '_user_email', '_user_url',
-    ) );
-}
-
-
 add_action( 'init', 'cfdb7_init');
 
 /**
@@ -325,6 +215,8 @@ add_action( 'init', 'cfdb7_init');
 function cfdb7_init(){
 
     do_action( 'cfdb7_init' );
+
+    require_once 'inc/special-mail-tags.php';
 
     if( is_admin() ){
 

--- a/inc/admin-form-details.php
+++ b/inc/admin-form-details.php
@@ -55,7 +55,8 @@ class CFDB7_Form_Details
                             $key     = esc_html( $key );
 
                             if ( $key == 'cfdb7_status' )  continue;
-                            if( $rm_underscore ) preg_match('/^_.*$/m', $key, $matches);
+                            if( $rm_underscore && ! in_array( $key, cfdb7_get_special_mail_tags() ) )
+                                preg_match('/^_.*$/m', $key, $matches);
                             if( ! empty($matches[0]) ) continue;
 
                             if ( strpos($key, 'cfdb7_file') !== false ){

--- a/inc/admin-subpage.php
+++ b/inc/admin-subpage.php
@@ -141,7 +141,8 @@ class CFDB7_List_Table extends WP_List_Table
 
                 if ( $key == 'cfdb7_status' ) continue;
 
-                if( $rm_underscore ) preg_match('/^_.*$/m', $key, $matches);
+                if( $rm_underscore && ! in_array( $key, cfdb7_get_special_mail_tags() ) )
+                    preg_match('/^_.*$/m', $key, $matches);
                 if( ! empty($matches[0]) ) continue;
 
                 $key_val       = str_replace( array('your-', 'cfdb7_file'), '', $key);

--- a/inc/export-csv.php
+++ b/inc/export-csv.php
@@ -119,7 +119,8 @@ class CFDB7_Export_CSV{
                         $matches = array();
 
                         if ( ! in_array( $key, $heading_key ) ) continue;
-                        if( $rm_underscore ) preg_match('/^_.*$/m', $key, $matches);
+                        if( $rm_underscore && ! in_array( $key, cfdb7_get_special_mail_tags() ) )
+                            preg_match('/^_.*$/m', $key, $matches);
                         if( ! empty($matches[0]) ) continue;
 
                         $value = str_replace( 

--- a/inc/special-mail-tags.php
+++ b/inc/special-mail-tags.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * CFDB7 Special Mail Tags
+ *
+ * Captures CF7 special mail tags used in form mail templates
+ * and saves them alongside form submission data.
+ *
+ * @since 1.3.6
+ */
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Get the list of CF7 special mail tags supported by CFDB7.
+ *
+ * @since 1.3.6
+ * @return array
+ */
+function cfdb7_get_special_mail_tags() {
+	return apply_filters( 'cfdb7_special_mail_tags', array(
+		'_remote_ip', '_user_agent', '_url', '_date', '_time',
+		'_post_id', '_post_name', '_post_title', '_post_url',
+		'_post_author', '_post_author_email', '_serial_number',
+		'_site_title', '_site_description', '_site_url', '_site_admin_email',
+		'_user_login', '_user_email', '_user_url',
+	) );
+}
+
+/**
+ * Resolve a special mail tag value using CF7's own wpcf7_special_mail_tags filter.
+ *
+ * @since 1.3.6
+ * @param string $tag_name The special tag name (e.g. '_remote_ip').
+ * @return string The resolved value.
+ */
+function cfdb7_resolve_special_mail_tag( $tag_name ) {
+	return apply_filters( 'wpcf7_special_mail_tags', '', $tag_name, false, null );
+}
+
+/**
+ * Detect which special mail tags are used in the form's mail templates
+ * and add their resolved values to the form data before saving.
+ *
+ * Hooked to cfdb7_before_save_data.
+ *
+ * @since 1.3.6
+ * @param array $form_data The form data to be saved.
+ * @return array Modified form data with special mail tags appended.
+ */
+function cfdb7_add_special_mail_tags( $form_data ) {
+	$submission = WPCF7_Submission::get_instance();
+
+	if ( ! $submission ) {
+		return $form_data;
+	}
+
+	$contact_form = $submission->get_contact_form();
+
+	if ( ! $contact_form ) {
+		return $form_data;
+	}
+
+	$all_special_tags = cfdb7_get_special_mail_tags();
+
+	// Collect all mail template content (mail + mail_2)
+	$mail_properties = (array) $contact_form->prop( 'mail' );
+	$mail_2 = (array) $contact_form->prop( 'mail_2' );
+
+	if ( ! empty( $mail_2['active'] ) ) {
+		$mail_properties = array_merge_recursive( $mail_properties, $mail_2 );
+	}
+
+	$mail_string = implode( ' ', array_map( function( $v ) {
+		return is_array( $v ) ? implode( ' ', $v ) : (string) $v;
+	}, $mail_properties ) );
+
+	// Find which special tags are actually used in the mail templates
+	$active_tags = array();
+	foreach ( $all_special_tags as $tag ) {
+		if ( strpos( $mail_string, '[' . $tag . ']' ) !== false ) {
+			$active_tags[] = $tag;
+		}
+	}
+
+	/**
+	 * Filter the list of special mail tags that will be saved for this form.
+	 *
+	 * @since 1.3.6
+	 * @param array              $active_tags   Tags detected in mail templates.
+	 * @param WPCF7_ContactForm  $contact_form  The contact form instance.
+	 */
+	$active_tags = apply_filters( 'cfdb7_active_special_mail_tags', $active_tags, $contact_form );
+
+	foreach ( $active_tags as $tag ) {
+		if ( isset( $form_data[ $tag ] ) ) {
+			continue;
+		}
+
+		// _serial_number is CFDB7-specific, not a native CF7 tag
+		if ( $tag === '_serial_number' ) {
+			global $wpdb;
+			$cfdb       = apply_filters( 'cfdb7_database', $wpdb );
+			$table_name = $cfdb->prefix . 'db7_forms';
+			$count      = $cfdb->get_var(
+				$cfdb->prepare(
+					"SELECT COUNT(*) FROM $table_name WHERE form_post_id = %d",
+					$contact_form->id()
+				)
+			);
+			$form_data[ $tag ] = (string) ( intval( $count ) + 1 );
+			continue;
+		}
+
+		// Delegate to CF7's native special mail tag resolution
+		$value = cfdb7_resolve_special_mail_tag( $tag );
+
+		if ( $value !== '' && $value !== false && $value !== null ) {
+			$form_data[ $tag ] = sanitize_text_field( (string) $value );
+		}
+	}
+
+	return $form_data;
+}
+
+add_filter( 'cfdb7_before_save_data', 'cfdb7_add_special_mail_tags' );


### PR DESCRIPTION
CFDB7 now automatically captures Contact Form 7 [special mail tags](https://contactform7.com/special-mail-tags/) and includes them in the admin views and CSV export.CFDB7 now automatically captures Contact Form 7 [special mail tags](https://contactform7.com/special-mail-tags/) and includes them in the admin views and CSV export.