### PR TITLE
v1.3.7

### DIFF
--- a/contact-form-cfdb-7.php
+++ b/contact-form-cfdb-7.php
@@ -8,7 +8,7 @@ Author URI: http://ciphercoin.com/
 Text Domain: contact-form-cfdb7
 License: GPL v2 or later
 Domain Path: /languages/
-Version: 1.3.5
+Version: 1.3.7
 */
 
 function cfdb7_create_table(){
@@ -97,6 +97,33 @@ function cfdb7_on_deactivate() {
 register_deactivation_hook( __FILE__, 'cfdb7_on_deactivate' );
 
 
+/**
+ * Unserialize stored form data, repairing broken string lengths when needed.
+ *
+ * @since 1.3.7
+ * @param string $data Serialized form data.
+ * @return array|false Form data array, false when the value holds no readable data.
+ */
+function cfdb7_unserialize( $data ) {
+
+    if ( ! is_string( $data ) ) return false;
+
+    $result = @unserialize( $data, array( 'allowed_classes' => false ) );
+    if ( is_array( $result ) ) return $result;
+
+    if ( strpos( $data, 'a:' ) !== 0 ) return false;
+
+    // string lengths no longer match when invalid characters were stripped after serialization
+    $repaired = preg_replace_callback(
+        '/s:\d+:"(.*?)";/s',
+        function( $m ) { return 's:'.strlen( $m[1] ).':"'.$m[1].'";'; },
+        $data
+    );
+    $result = @unserialize( $repaired, array( 'allowed_classes' => false ) );
+
+    return is_array( $result ) ? $result : false;
+}
+
 function cfdb7_before_send_mail( $form_tag ) {
 
     global $wpdb;
@@ -136,7 +163,7 @@ function cfdb7_before_send_mail( $form_tag ) {
         foreach ($_FILES as $file_key => $file) {
             array_push($uploaded_files, $file_key);
         }
-        
+
         /**
          * Filters the uploaded files array before copying to cfdb7_uploads.
          *
@@ -165,10 +192,11 @@ function cfdb7_before_send_mail( $form_tag ) {
                 $tmpD = $d;
 
                 if ( ! is_array($d) ){
+                    $tmpD = wp_check_invalid_utf8( $tmpD, true );
                     $tmpD = str_replace($bl, $wl, $tmpD );
                 }else{
                     $tmpD = array_map(function($item) use($bl, $wl){
-                               return str_replace($bl, $wl, $item ); 
+                               return str_replace($bl, $wl, wp_check_invalid_utf8( $item, true ) );
                             }, $tmpD);
                 }
 

--- a/inc/admin-form-details.php
+++ b/inc/admin-form-details.php
@@ -47,7 +47,13 @@ class CFDB7_Form_Details
                         
                         <p></span><?php  esc_html_e( $result->form_date, 'contact-form-cfdb7' ) ?></p>
                         
-                        <?php $form_data  = unserialize( $result->form_value, ['allowed_classes' => false] );
+                        <?php $form_data  = cfdb7_unserialize( $result->form_value );
+
+                        if ( ! is_array($form_data) ):
+
+                            echo '<p>'.esc_html__( 'This entry contains no readable form data.', 'contact-form-cfdb7' ).'</p>';
+
+                        else:
 
                         foreach ($form_data as $key => $data):
 
@@ -101,6 +107,8 @@ class CFDB7_Form_Details
                             $form_id  
                         );
                         $cfdb->query( $sql );
+
+                        endif;
                         ?>
                     </div>
                 </div>

--- a/inc/admin-subpage.php
+++ b/inc/admin-subpage.php
@@ -54,7 +54,7 @@ if( ! class_exists( 'WP_List_Table' ) ) {
 class CFDB7_List_Table extends WP_List_Table
 {
     private $form_post_id;
-    private $column_titles;
+    private $column_titles = array();
 
     public function __construct() {
 
@@ -122,12 +122,21 @@ class CFDB7_List_Table extends WP_List_Table
         global $wpdb;
         $cfdb          = apply_filters( 'cfdb7_database', $wpdb );
         $table_name    = $cfdb->prefix.'db7_forms';
+        // serialized arrays always start with a:, skip rows holding no readable data
         $results       = $cfdb->get_results( "
-            SELECT * FROM $table_name 
-            WHERE form_post_id = $form_post_id ORDER BY form_id DESC LIMIT 1", OBJECT 
+            SELECT * FROM $table_name
+            WHERE form_post_id = $form_post_id AND form_value LIKE 'a:%'
+            ORDER BY form_id DESC LIMIT 5", OBJECT
         );
 
-        $first_row            = isset($results[0]) ? unserialize( $results[0]->form_value, ['allowed_classes' => false] ): 0 ;
+        $first_row = 0;
+        foreach ( $results as $result ) {
+            $row = cfdb7_unserialize( $result->form_value );
+            if ( is_array($row) ) {
+                $first_row = $row;
+                break;
+            }
+        }
         $columns              = array();
         $rm_underscore        = apply_filters('cfdb7_remove_underscore_data', true); 
 
@@ -152,6 +161,10 @@ class CFDB7_List_Table extends WP_List_Table
 
                 if ( sizeof($columns) > 4) break;
             }
+            $columns['form-date'] = 'Date';
+        }else{
+            // no readable rows found, still list entries so they can be opened or deleted
+            $columns['cb']        = '<input type="checkbox" />';
             $columns['form-date'] = 'Date';
         }
 
@@ -241,7 +254,12 @@ class CFDB7_List_Table extends WP_List_Table
 
         foreach ( $results as $result ) {
 
-            $form_value = unserialize( $result->form_value, ['allowed_classes' => false] );
+            $form_value = cfdb7_unserialize( $result->form_value );
+
+            // keep corrupted rows listed so they can still be opened or bulk deleted
+            if ( ! is_array($form_value) ) {
+                $form_value = array( 'cfdb7_status' => 'unread' );
+            }
 
             $link  = "<b><a href=admin.php?page=cfdb7-list.php&fid=%s&ufid=%s>%s</a></b>";
             if(isset($form_value['cfdb7_status']) && ( $form_value['cfdb7_status'] === 'read' ) )
@@ -316,7 +334,8 @@ class CFDB7_List_Table extends WP_List_Table
                 $form_id       = (int) $form_id;
                 $results       = $cfdb->get_results( "SELECT * FROM $table_name WHERE form_id = '$form_id' LIMIT 1", OBJECT );
                 $result_value  = $results[0]->form_value;
-                $result_values = unserialize($result_value, ['allowed_classes' => false]);
+                $result_values = cfdb7_unserialize( $result_value );
+                $result_values = is_array($result_values) ? $result_values : array();
                 $upload_dir    = wp_upload_dir();
                 $cfdb7_dirname = $upload_dir['basedir'].'/cfdb7_uploads';
 
@@ -346,7 +365,8 @@ class CFDB7_List_Table extends WP_List_Table
                 $form_id       = (int) $form_id;
                 $results       = $cfdb->get_results( "SELECT * FROM $table_name WHERE form_id = '$form_id' LIMIT 1", OBJECT );
                 $result_value  = $results[0]->form_value;
-                $result_values = unserialize( $result_value, ['allowed_classes' => false] );
+                $result_values = cfdb7_unserialize( $result_value );
+                if ( ! is_array($result_values) ) continue;
                 $result_values['cfdb7_status'] = 'read';
                 $form_data = serialize( $result_values );
                 
@@ -366,7 +386,8 @@ class CFDB7_List_Table extends WP_List_Table
                 $form_id       = (int) $form_id;
                 $results       = $cfdb->get_results( "SELECT * FROM $table_name WHERE form_id = '$form_id' LIMIT 1", OBJECT );
                 $result_value  = $results[0]->form_value;
-                $result_values = unserialize( $result_value, ['allowed_classes' => false] );
+                $result_values = cfdb7_unserialize( $result_value );
+                if ( ! is_array($result_values) ) continue;
                 $result_values['cfdb7_status'] = 'unread';
                 $form_data = serialize( $result_values );
                 $sql = $cfdb->prepare(

--- a/inc/export-csv.php
+++ b/inc/export-csv.php
@@ -81,11 +81,18 @@ class CFDB7_Export_CSV{
                 wp_die( 'Not Valid.. Download nonce..!! ' );
             }
             $fid         = (int)$_REQUEST['fid'];
-            $heading_row = $cfdb->get_results("SELECT form_id, form_value, form_date FROM $table_name
-                WHERE form_post_id = '$fid' ORDER BY form_id DESC LIMIT 1",OBJECT);
+            $heading_rows = $cfdb->get_results("SELECT form_id, form_value, form_date FROM $table_name
+                WHERE form_post_id = '$fid' ORDER BY form_id DESC LIMIT 5",OBJECT);
 
-            $heading_row    = reset( $heading_row );
-            $heading_row    = unserialize( $heading_row->form_value, ['allowed_classes' => false] );
+            // use newest row that unserializes cleanly, corrupted rows would break the export
+            $heading_row = array();
+            foreach ( $heading_rows as $row ) {
+                $row_value = cfdb7_unserialize( $row->form_value );
+                if ( is_array($row_value) ) {
+                    $heading_row = $row_value;
+                    break;
+                }
+            }
             $heading_key    = array_keys( $heading_row );
             $rm_underscore  = apply_filters('cfdb7_remove_underscore_data', true); 
 
@@ -111,7 +118,8 @@ class CFDB7_Export_CSV{
                     $i++;
                     $data['form_id'][$i]    = $result->form_id;
                     $data['form_date'][$i]  = $result->form_date;
-                    $resultTmp              = unserialize( $result->form_value, ['allowed_classes' => false] );
+                    $resultTmp              = cfdb7_unserialize( $result->form_value );
+                    $resultTmp              = is_array($resultTmp) ? $resultTmp : array();
                     $upload_dir             = wp_upload_dir();
                     $cfdb7_dir_url          = $upload_dir['baseurl'].'/cfdb7_uploads';
 


### PR DESCRIPTION
- Adds error catching for bad entry data that breaks un-serialization while attempting to render admin page views for entries.
- Ups to 1.3.7 (based on WordPress.org version being on 1.3.6 despite being 1.3.5 on GitHub)